### PR TITLE
Feature/initial release

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ return [
 ];
 ```
 
+### Step 3: Create and execute migration
+
+The event_sent table needs to be created. To do this, execute:
+
+```shell
+bin/console doctrine:migrations:diff
+# Check if your migration is correct first.
+bin/console doctrine:migrations:migrate
+```
+
 Documentation
 =============
 

--- a/config/hallo_verden_queue_notifications.yaml
+++ b/config/hallo_verden_queue_notifications.yaml
@@ -1,0 +1,13 @@
+hallo_verden_queue_notifications:
+    message_queue_stopped_event:
+        transports:
+            async:
+                max_handle_time: 300
+                event_interval: 1800
+                max_events: 100
+    message_queue_has_messages_event:
+        transports:
+            failed:
+                event_interval: 1800
+                max_events: 100
+                max_messages: 0

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,0 +1,23 @@
+services:
+    hallo_verden_queue_notifications.event_sent_repository:
+        class: HalloVerden\MessengerQueueNotificationsBundle\Repository\EventSentRepository
+        arguments:
+            $registry: '@doctrine'
+
+    hallo_verden_queue_notifications.listener.check_message_queue_stopped:
+        class: HalloVerden\MessengerQueueNotificationsBundle\EventListener\CheckMessageQueueStoppedListener
+        arguments:
+            $eventSentRepository: '@hallo_verden_queue_notifications.event_sent_repository'
+            $eventDispatcher: '@event_dispatcher'
+            $configs: !abstract defined in extenstion
+        tags:
+            - { name: kernel.event_subscriber }
+
+    hallo_verden_queue_notifications.listener.check_message_queue_has_messages:
+        class: HalloVerden\MessengerQueueNotificationsBundle\EventListener\CheckMessageQueueHasMessagesListener
+        arguments:
+            $eventSentRepository: '@hallo_verden_queue_notifications.event_sent_repository'
+            $eventDispatcher: '@event_dispatcher'
+            $configs: !abstract defined in extenstion
+        tags:
+            - { name: kernel.event_subscriber }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -9,7 +9,7 @@ services:
         arguments:
             $eventSentRepository: '@hallo_verden_queue_notifications.event_sent_repository'
             $eventDispatcher: '@event_dispatcher'
-            $configs: !abstract defined in extenstion
+            $configs: !abstract defined in extension
         tags:
             - { name: kernel.event_subscriber }
 
@@ -18,6 +18,6 @@ services:
         arguments:
             $eventSentRepository: '@hallo_verden_queue_notifications.event_sent_repository'
             $eventDispatcher: '@event_dispatcher'
-            $configs: !abstract defined in extenstion
+            $configs: !abstract defined in extension
         tags:
             - { name: kernel.event_subscriber }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,32 @@
 Configuration
 =============
 
-Coming soon...
+```yaml
+hallo_verden_queue_notifications:
+    message_queue_stopped_event:
+        transports:
+            async:
+                max_handle_time: 300
+                event_interval: 1800
+                max_events: 2
+    message_queue_has_messages_event:
+        transports:
+            failed:
+                event_interval: 1800
+                max_events: 10
+                max_messages: 0
+```
+
+Here `MessageQueueStoppedEvent` will get dispatched if the message queue has stopped for 300 seconds or more 
+every 1800 seconds and maximum 2 events.
+
+Also `MessageQueueHasMessagesEvent` will get dispatched if the failed transport has messages every 1800 seconds,
+maximum 10 times.
 
 Usage
 =====
 
-Comming soon...
+Create a cronjob that executes `bin/console hallo_verden:messenger_queue_events:dispatch`
+at a desired interval (i.e. every 15 seconds)
+
+You can now create event listeners to act on these events.

--- a/src/Config/AbstractCheckMessageQueueConfig.php
+++ b/src/Config/AbstractCheckMessageQueueConfig.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\Config;
+
+
+abstract class AbstractCheckMessageQueueConfig {
+  const OPTION_EVENT_INTERVAL = 'event_interval';
+  const OPTION_MAX_EVENTS = 'max_events';
+
+  private int $eventInterval;
+  private int $maxEvents;
+
+  /**
+   * CheckMessageQueueStoppedConfig constructor.
+   *
+   * @param int $maxHandleTime
+   * @param int $eventInterval
+   */
+  public function __construct(int $eventInterval, int $maxEvents) {
+    $this->eventInterval = $eventInterval;
+    $this->maxEvents = $maxEvents;
+  }
+
+  /**
+   * @param array $configArray
+   *
+   * @return static
+   */
+  public static function createFromConfigArray(array $configArray): self {
+    return new static(
+      $configArray[self::OPTION_EVENT_INTERVAL],
+      $configArray[self::OPTION_MAX_EVENTS],
+    );
+  }
+
+  /**
+   * @param array $configsArray
+   *
+   * @return array
+   */
+  public static function createFromConfigsArray(array $configsArray): array {
+    $configs = [];
+
+    foreach ($configsArray as $transport => $configArray) {
+      $configs[$transport] = static::createFromConfigArray($configArray);
+    }
+
+    return $configs;
+  }
+
+  /**
+   * @return int
+   */
+  public function getEventInterval(): int {
+    return $this->eventInterval;
+  }
+
+  /**
+   * @return int
+   */
+  public function getMaxEvents(): int {
+    return $this->maxEvents;
+  }
+}

--- a/src/Config/CheckMessageQueueHasMessagesConfig.php
+++ b/src/Config/CheckMessageQueueHasMessagesConfig.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\Config;
+
+/**
+ * Class CheckMessageQueueHasMessagesConfig
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\Config
+ */
+class CheckMessageQueueHasMessagesConfig extends AbstractCheckMessageQueueConfig {
+  const OPTION_MAX_MESSAGES = 'max_messages';
+
+  private int $maxMessages;
+
+
+  /**
+   * @inheritDoc
+   */
+  public static function createFromConfigArray(array $configArray): self {
+    $config = parent::createFromConfigArray($configArray);
+    $config->maxMessages = $configArray[self::OPTION_MAX_MESSAGES];
+    return $config;
+  }
+
+  /**
+   * @return int
+   */
+  public function getMaxMessages(): int {
+    return $this->maxMessages;
+  }
+
+}

--- a/src/Config/CheckMessageQueueStoppedConfig.php
+++ b/src/Config/CheckMessageQueueStoppedConfig.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\Config;
+
+/**
+ * Class CheckMessageQueueStoppedConfig
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\Config
+ */
+class CheckMessageQueueStoppedConfig extends AbstractCheckMessageQueueConfig {
+  const OPTION_MAX_HANDLE_TIME = 'max_handle_time';
+
+  private int $maxHandleTime;
+
+  /**
+   * @inheritDoc
+   */
+  public static function createFromConfigArray(array $configArray): self {
+    $config = parent::createFromConfigArray($configArray);
+    $config->maxHandleTime = $configArray[self::OPTION_MAX_HANDLE_TIME];
+    return $config;
+  }
+
+  /**
+   * @return int
+   */
+  public function getMaxHandleTime(): int {
+    return $this->maxHandleTime;
+  }
+
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,62 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\DependencyInjection;
+
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * Class Configuration
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\DependencyInjection
+ */
+class Configuration implements ConfigurationInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function getConfigTreeBuilder(): TreeBuilder {
+    $treeBuilder = new TreeBuilder('hallo_verden_messenger_queue_notifications');
+
+    $treeBuilder->getRootNode()
+      ->children()
+        ->arrayNode('message_queue_stopped_event')
+          ->addDefaultsIfNotSet()
+          ->children()
+            ->arrayNode('transports')
+              ->arrayPrototype()
+                ->children()
+                  ->integerNode('max_handle_time')->defaultValue(300)->end()
+                  ->integerNode('event_interval')->defaultValue(1800)->end()
+                  ->integerNode('max_events')->defaultValue(100)->end()
+                ->end()
+              ->end()
+            ->end()
+          ->end()
+        ->end()
+      ->end();
+
+    $treeBuilder->getRootNode()
+      ->children()
+        ->arrayNode('message_queue_has_messages_event')
+          ->addDefaultsIfNotSet()
+          ->children()
+            ->arrayNode('transports')
+              ->arrayPrototype()
+                ->children()
+                  ->integerNode('max_messages')->defaultValue(1)->end()
+                  ->integerNode('event_interval')->defaultValue(1800)->end()
+                  ->integerNode('max_events')->defaultValue(100)->end()
+                ->end()
+              ->end()
+            ->end()
+          ->end()
+        ->end()
+      ->end();
+
+    return $treeBuilder;
+  }
+
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -46,7 +46,7 @@ class Configuration implements ConfigurationInterface {
             ->arrayNode('transports')
               ->arrayPrototype()
                 ->children()
-                  ->integerNode('max_messages')->defaultValue(1)->end()
+                  ->integerNode('max_messages')->defaultValue(0)->end()
                   ->integerNode('event_interval')->defaultValue(1800)->end()
                   ->integerNode('max_events')->defaultValue(100)->end()
                 ->end()

--- a/src/DependencyInjection/HalloVerdenMessengerQueueNotificationsExtension.php
+++ b/src/DependencyInjection/HalloVerdenMessengerQueueNotificationsExtension.php
@@ -1,0 +1,66 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\DependencyInjection;
+
+
+use HalloVerden\MessengerQueueEventsBundle\Event\MessageQueueEvent;
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
+
+/**
+ * Class HalloVerdenMessengerQueueNotificationsExtension
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\DependencyInjection
+ */
+class HalloVerdenMessengerQueueNotificationsExtension extends ConfigurableExtension implements PrependExtensionInterface {
+
+  /**
+   * @inheritDoc
+   * @throws \Exception
+   */
+  protected function loadInternal(array $mergedConfig, ContainerBuilder $container) {
+    $loader = new YamlFileLoader($container, new FileLocator(__DIR__. '/../../config'));
+    $loader->load('services.yaml');
+
+    $container->getDefinition('hallo_verden_queue_notifications.listener.check_message_queue_stopped')
+      ->setArgument('$configs', $mergedConfig['message_queue_stopped_event']['transports']);
+
+    $container->getDefinition('hallo_verden_queue_notifications.listener.check_message_queue_has_messages')
+      ->setArgument('$configs', $mergedConfig['message_queue_has_messages_event']['transports']);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function prepend(ContainerBuilder $container) {
+    $configs = $container->getExtensionConfig($this->getAlias());
+    $resolvingBag = $container->getParameterBag();
+
+    // This is a internal method, but I find no other way of solving this.
+    //   see https://github.com/symfony/symfony/issues/31608 + https://github.com/symfony/symfony/issues/40198
+    BaseNode::setPlaceholderUniquePrefix($resolvingBag->getEnvPlaceholderUniquePrefix());
+
+    $configs = $resolvingBag->resolveValue($configs);
+    $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
+
+    $mapping = [];
+
+    foreach (array_keys($config['message_queue_stopped_event']['transports']) as $transport) {
+      $mapping[$transport] = [MessageQueueEvent::EVENT_INFORMATION_FIRST_AVAILABLE_MESSAGE, MessageQueueEvent::EVENT_INFORMATION_MESSAGE_COUNT];
+    }
+
+    foreach (array_keys($config['message_queue_has_messages_event']['transports']) as $transport) {
+      $mapping[$transport] = \array_merge($mapping[$transport] ?? [], [MessageQueueEvent::EVENT_INFORMATION_MESSAGE_COUNT]);
+    }
+
+    $container->prependExtensionConfig('hallo_verden_messenger_queue_events', [
+      'transport_event_information_mapping' => $mapping
+    ]);
+  }
+
+}

--- a/src/Entity/EventSent.php
+++ b/src/Entity/EventSent.php
@@ -1,0 +1,120 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class EventSent
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\Entity
+ *
+ * @ORM\Entity()
+ */
+class EventSent {
+
+  /**
+   * @var int
+   *
+   * @ORM\Id()
+   * @ORM\GeneratedValue(strategy="AUTO")
+   * @ORM\Column(name="id", type="integer", unique=true)
+   */
+  private int $id;
+
+  /**
+   * @var string
+   *
+   * @ORM\Column(name="event", type="string", nullable=false)
+   */
+  private string $event;
+
+  /**
+   * @var int
+   *
+   * @ORM\Column(name="count", type="integer", nullable=false)
+   */
+  private int $count;
+
+  /**
+   * @var string
+   *
+   * @ORM\Column(name="transport", type="string", nullable=false)
+   */
+  private string $transport;
+
+  /**
+   * @var \DateTime
+   *
+   * @ORM\Column(name="last_sent", type="datetime", nullable=false)
+   */
+  private \DateTime $lastSent;
+
+  /**
+   * EventSent constructor.
+   *
+   * @param string $event
+   * @param string $transport
+   */
+  public function __construct(string $event, string $transport) {
+    $this->event = $event;
+    $this->transport = $transport;
+    $this->count = 1;
+    $this->lastSent = new \DateTime();
+  }
+
+  /**
+   * @return int
+   */
+  public function getId(): int {
+    return $this->id;
+  }
+
+  /**
+   * @return string
+   */
+  public function getEvent(): string {
+    return $this->event;
+  }
+
+  /**
+   * @return int
+   */
+  public function getCount(): int {
+    return $this->count;
+  }
+
+  /**
+   * @return EventSent
+   */
+  public function incrementCount(): self {
+    $this->count++;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getTransport(): string {
+    return $this->transport;
+  }
+
+  /**
+   * @return \DateTime
+   */
+  public function getLastSent(): \DateTime {
+    return $this->lastSent;
+  }
+
+  /**
+   * @param \DateTime $lastSent
+   *
+   * @return EventSent
+   */
+  public function setLastSent(\DateTime $lastSent): self {
+    $this->lastSent = $lastSent;
+    return $this;
+  }
+
+}

--- a/src/Event/AbstractMessageQueueEvent.php
+++ b/src/Event/AbstractMessageQueueEvent.php
@@ -1,0 +1,62 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\Event;
+
+use HalloVerden\MessengerQueueEventsBundle\Event\MessageQueueEvent;
+use HalloVerden\MessengerQueueNotificationsBundle\Config\AbstractCheckMessageQueueConfig;
+
+/**
+ * Class AbstractMessageQueueEvent
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\Event
+ */
+abstract class AbstractMessageQueueEvent {
+  private int $count;
+  private MessageQueueEvent $messageQueueEvent;
+  private AbstractCheckMessageQueueConfig $config;
+
+  /**
+   * MessageQueueHasMessagesEvent constructor.
+   *
+   * @param MessageQueueEvent $messageQueueEvent
+   */
+  public function __construct(MessageQueueEvent $messageQueueEvent, AbstractCheckMessageQueueConfig $config) {
+    $this->messageQueueEvent = $messageQueueEvent;
+    $this->config = $config;
+  }
+
+  /**
+   * @return int
+   */
+  public function getCount(): int {
+    return $this->count;
+  }
+
+  /**
+   * @internal
+   *
+   * @param int $count
+   *
+   * @return AbstractMessageQueueEvent
+   */
+  public function setCount(int $count): self {
+    $this->count = $count;
+    return $this;
+  }
+
+  /**
+   * @return MessageQueueEvent
+   */
+  public function getMessageQueueEvent(): MessageQueueEvent {
+    return $this->messageQueueEvent;
+  }
+
+  /**
+   * @return AbstractCheckMessageQueueConfig
+   */
+  public function getConfig(): AbstractCheckMessageQueueConfig {
+    return $this->config;
+  }
+
+}

--- a/src/Event/MessageQueueHasMessagesEvent.php
+++ b/src/Event/MessageQueueHasMessagesEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\Event;
+
+
+/**
+ * Class MessageQueueHasMessagesEvent
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\Event
+ */
+class MessageQueueHasMessagesEvent extends AbstractMessageQueueEvent {
+
+}

--- a/src/Event/MessageQueueStoppedEvent.php
+++ b/src/Event/MessageQueueStoppedEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\Event;
+
+/**
+ * Class MessageQueueStoppedEvent
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\Event
+ */
+class MessageQueueStoppedEvent extends AbstractMessageQueueEvent {
+}

--- a/src/EventListener/AbstractMessageQueueListener.php
+++ b/src/EventListener/AbstractMessageQueueListener.php
@@ -1,0 +1,110 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\EventListener;
+
+
+use HalloVerden\MessengerQueueEventsBundle\Event\MessageQueueEvent;
+use HalloVerden\MessengerQueueNotificationsBundle\Config\AbstractCheckMessageQueueConfig;
+use HalloVerden\MessengerQueueNotificationsBundle\Entity\EventSent;
+use HalloVerden\MessengerQueueNotificationsBundle\Event\AbstractMessageQueueEvent;
+use HalloVerden\MessengerQueueNotificationsBundle\Repository\EventSentRepositoryInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class AbstractMessageQueueListener
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\EventListener
+ */
+abstract class AbstractMessageQueueListener implements EventSubscriberInterface {
+  private EventSentRepositoryInterface $eventSentRepository;
+  private EventDispatcherInterface $eventDispatcher;
+
+  /**
+   * @var AbstractCheckMessageQueueConfig[]
+   */
+  private array $configs;
+
+  /**
+   * AbstractMessageQueueListener constructor.
+   */
+  public function __construct(EventSentRepositoryInterface $eventSentRepository, EventDispatcherInterface $eventDispatcher, array $configs) {
+    $this->eventSentRepository = $eventSentRepository;
+    $this->eventDispatcher = $eventDispatcher;
+    $this->configs = static::getConfigClass()::createFromConfigsArray($configs);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      MessageQueueEvent::class => 'onMessageQueueEvent'
+    ];
+  }
+
+  /**
+   * @return AbstractCheckMessageQueueConfig|string
+   */
+  abstract protected static function getConfigClass(): string;
+
+  /**
+   * @param MessageQueueEvent               $event
+   * @param AbstractCheckMessageQueueConfig $config
+   *
+   * @return AbstractMessageQueueEvent
+   */
+  abstract protected function createMessageQueueEvent(MessageQueueEvent $event, AbstractCheckMessageQueueConfig $config): AbstractMessageQueueEvent;
+
+  /**
+   * @param MessageQueueEvent               $event
+   * @param AbstractCheckMessageQueueConfig $config
+   *
+   * @return bool
+   */
+  abstract protected function shouldTakeAction(MessageQueueEvent $event, AbstractCheckMessageQueueConfig $config): bool;
+
+  /**
+   * @param MessageQueueEvent $event
+   */
+  public function onMessageQueueEvent(MessageQueueEvent $event): void {
+    $config = $this->configs[$event->getTransport()] ?? null;
+    if (null === $config) {
+      return;
+    }
+
+    $messageQueueEvent = $this->createMessageQueueEvent($event, $config);
+
+    $eventSent = $this->eventSentRepository->getByEventAndTransport(get_class($messageQueueEvent), $event->getTransport());
+
+    if ($this->shouldTakeAction($event, $config)) {
+      $this->dispatchUnlessRecentlySentOrMaxEvents($messageQueueEvent, $eventSent, $config);
+    } elseif (null !== $eventSent) {
+      $this->eventSentRepository->delete($eventSent);
+    }
+  }
+
+  /**
+   * @param AbstractMessageQueueEvent       $messageQueueEvent
+   * @param EventSent|null                  $eventSent
+   * @param AbstractCheckMessageQueueConfig $config
+   */
+  protected function dispatchUnlessRecentlySentOrMaxEvents(AbstractMessageQueueEvent $messageQueueEvent, ?EventSent $eventSent, AbstractCheckMessageQueueConfig $config): void {
+    if (null === $eventSent) {
+      $this->eventDispatcher->dispatch($messageQueueEvent->setCount(1));
+      $this->eventSentRepository->create(new EventSent(\get_class($messageQueueEvent), $messageQueueEvent->getMessageQueueEvent()->getTransport()));
+      return;
+    }
+
+    if ($eventSent->getCount() >= $config->getMaxEvents()) {
+      return;
+    }
+
+    if (time() - $eventSent->getLastSent()->getTimestamp() >= $config->getEventInterval()) {
+      $this->eventDispatcher->dispatch($messageQueueEvent->setCount($eventSent->getCount() + 1));
+      $this->eventSentRepository->updateLastSentNow($eventSent);
+    }
+  }
+
+}

--- a/src/EventListener/CheckMessageQueueHasMessagesListener.php
+++ b/src/EventListener/CheckMessageQueueHasMessagesListener.php
@@ -1,0 +1,55 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\EventListener;
+
+
+use HalloVerden\MessengerQueueEventsBundle\Event\MessageQueueEvent;
+use HalloVerden\MessengerQueueNotificationsBundle\Config\AbstractCheckMessageQueueConfig;
+use HalloVerden\MessengerQueueNotificationsBundle\Config\CheckMessageQueueHasMessagesConfig;
+use HalloVerden\MessengerQueueNotificationsBundle\Event\AbstractMessageQueueEvent;
+use HalloVerden\MessengerQueueNotificationsBundle\Event\MessageQueueHasMessagesEvent;
+use HalloVerden\MessengerQueueNotificationsBundle\Repository\EventSentRepositoryInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Class CheckMessageQueueHasMessagesListener
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\EventListener
+ */
+class CheckMessageQueueHasMessagesListener extends AbstractMessageQueueListener {
+
+  /**
+   * CheckMessageQueueHasMessagesListener constructor.
+   *
+   * @param EventSentRepositoryInterface $eventSentRepository
+   * @param EventDispatcherInterface     $eventDispatcher
+   * @param array                        $configs
+   */
+  public function __construct(EventSentRepositoryInterface $eventSentRepository, EventDispatcherInterface $eventDispatcher, array $configs) {
+    parent::__construct($eventSentRepository, $eventDispatcher, $configs);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected static function getConfigClass(): string {
+    return CheckMessageQueueHasMessagesConfig::class;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function createMessageQueueEvent(MessageQueueEvent $event, AbstractCheckMessageQueueConfig $config): AbstractMessageQueueEvent {
+    return new MessageQueueHasMessagesEvent($event, $config);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function shouldTakeAction(MessageQueueEvent $event, AbstractCheckMessageQueueConfig $config): bool {
+    return $config instanceof CheckMessageQueueHasMessagesConfig
+      && $event->getMessageCount() > $config->getMaxMessages();
+  }
+
+}

--- a/src/EventListener/CheckMessageQueueStoppedListener.php
+++ b/src/EventListener/CheckMessageQueueStoppedListener.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\EventListener;
+
+
+use HalloVerden\MessengerQueueEventsBundle\Event\MessageQueueEvent;
+use HalloVerden\MessengerQueueNotificationsBundle\Config\AbstractCheckMessageQueueConfig;
+use HalloVerden\MessengerQueueNotificationsBundle\Config\CheckMessageQueueStoppedConfig;
+use HalloVerden\MessengerQueueNotificationsBundle\Event\AbstractMessageQueueEvent;
+use HalloVerden\MessengerQueueNotificationsBundle\Event\MessageQueueStoppedEvent;
+
+/**
+ * Class CheckMessageQueueStoppedListener
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\EventListener
+ */
+class CheckMessageQueueStoppedListener extends AbstractMessageQueueListener {
+
+  /**
+   * @inheritDoc
+   */
+  protected static function getConfigClass(): string {
+    return CheckMessageQueueStoppedConfig::class;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function createMessageQueueEvent(MessageQueueEvent $event, AbstractCheckMessageQueueConfig $config): AbstractMessageQueueEvent {
+    return new MessageQueueStoppedEvent($event, $config);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function shouldTakeAction(MessageQueueEvent $event, AbstractCheckMessageQueueConfig $config): bool {
+    $firstAvailableMessage = $event->getFirstAvailableMessage();
+
+    return $config instanceof CheckMessageQueueStoppedConfig
+      && null !== $firstAvailableMessage
+      && (time() - $firstAvailableMessage->getAvailableAt()->getTimestamp()) > $config->getMaxHandleTime();
+  }
+
+}

--- a/src/HalloVerdenMessengerQueueNotificationsBundle.php
+++ b/src/HalloVerdenMessengerQueueNotificationsBundle.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle;
+
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Class HalloVerdenMessengerQueueNotificationsBundle
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle
+ */
+class HalloVerdenMessengerQueueNotificationsBundle extends Bundle {
+
+}

--- a/src/Repository/EventSentRepository.php
+++ b/src/Repository/EventSentRepository.php
@@ -1,0 +1,75 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\Repository;
+
+use DateTime;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Doctrine\Persistence\ManagerRegistry;
+use HalloVerden\MessengerQueueNotificationsBundle\Entity\EventSent;
+
+/**
+ * @method EventSent|null find($id, $lockMode = null, $lockVersion = null)
+ * @method EventSent|null findOneBy(array $criteria, array $orderBy = null)
+ * @method EventSent[]    findAll()
+ * @method EventSent[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class EventSentRepository extends ServiceEntityRepository implements EventSentRepositoryInterface {
+
+  /**
+   * EventSentRepository constructor.
+   *
+   * @param ManagerRegistry $registry
+   */
+  public function __construct(ManagerRegistry $registry) {
+    parent::__construct($registry, EventSent::class);
+  }
+
+  /**
+   * @inheritDoc
+   * @throws ORMException
+   */
+  public function create(EventSent $eventSent): EventSent {
+    $this->getEntityManager()->persist($eventSent);
+    $this->getEntityManager()->flush();
+
+    return $eventSent;
+  }
+
+  /**
+   * @inheritDoc
+   * @throws ORMException
+   * @throws OptimisticLockException
+   */
+  public function updateLastSentNow(EventSent $eventSent): EventSent {
+    $eventSent->setLastSent(new DateTime())->incrementCount();
+    $this->getEntityManager()->flush();
+
+    return $eventSent;
+  }
+
+  /**
+   * @inheritDoc
+   * @throws ORMException
+   * @throws OptimisticLockException
+   */
+  public function delete(EventSent $eventSent): EventSent {
+    $this->getEntityManager()->remove($eventSent);
+    $this->getEntityManager()->flush();
+
+    return $eventSent;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getByEventAndTransport(string $event, string $transport): ?EventSent {
+    return $this->findOneBy([
+      'event' => $event,
+      'transport' => $transport
+    ]);
+  }
+
+}

--- a/src/Repository/EventSentRepositoryInterface.php
+++ b/src/Repository/EventSentRepositoryInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace HalloVerden\MessengerQueueNotificationsBundle\Repository;
+
+use HalloVerden\MessengerQueueNotificationsBundle\Entity\EventSent;
+
+/**
+ * Interface EventSentRepositoryInterface
+ *
+ * @package HalloVerden\MessengerQueueNotificationsBundle\Repository
+ */
+interface EventSentRepositoryInterface {
+
+  /**
+   * @param EventSent $eventSent
+   *
+   * @return EventSent
+   */
+  public function create(EventSent $eventSent): EventSent;
+
+  /**
+   * @param EventSent $eventSent
+   *
+   * @return EventSent
+   */
+  public function updateLastSentNow(EventSent $eventSent): EventSent;
+
+  /**
+   * @param EventSent $eventSent
+   *
+   * @return EventSent
+   */
+  public function delete(EventSent $eventSent): EventSent;
+
+  /**
+   * @param string $event
+   * @param string $transport
+   *
+   * @return EventSent|null
+   */
+  public function getByEventAndTransport(string $event, string $transport): ?EventSent;
+
+}


### PR DESCRIPTION
PR dependency: halloverden/symfony-messenger-queue-events-bundle#1

Dispatches MessageQueueStoppedEvent when message queue is stopped.
Dispatches MessageQueueHasMessagesEvent when transport has messages (usually failed transport).